### PR TITLE
collate server and client errors

### DIFF
--- a/client/exec.go
+++ b/client/exec.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/zenith"
+	pkg "github.com/zenith"
+	errors "github.com/zenith/errors/client"
 
 	resp "github.com/zenith/redis-protocol"
 )
@@ -61,19 +62,19 @@ func (c *client) Exec(input []string) {
 		fmt.Fprint(os.Stderr, err)
 	}
 
-	fmt.Fprint(os.Stdout, clientOutput.String()+zenith.LineFeed)
+	fmt.Fprint(os.Stdout, clientOutput.String()+pkg.LineFeed)
 }
 
 func validate(args []string) error {
 	cmd := args[0]
 
-	count, ok := zenith.Arguments(strings.ToUpper(cmd))
+	count, ok := pkg.Arguments(strings.ToUpper(cmd))
 	if !ok {
-		return zenith.UnknownCommand{Command: cmd, Args: args[1:]}
+		return errors.UnknownCommand{Command: cmd, Args: args[1:]}
 	}
 
 	if len(args)-1 != count {
-		return zenith.InvalidArgs{Command: cmd}
+		return errors.InvalidArgs{Command: cmd}
 	}
 
 	return nil

--- a/errors/client/error.go
+++ b/errors/client/error.go
@@ -1,4 +1,4 @@
-package zenith
+package client
 
 import "fmt"
 
@@ -17,20 +17,4 @@ type UnknownCommand struct {
 
 func (u UnknownCommand) Error() string {
 	return fmt.Sprintf("(error) ERR unknown command '%v', with args beginning with: %v", u.Command, u.Args)
-}
-
-type ProtocolError struct {
-	Message string
-}
-
-func (p ProtocolError) Error() string {
-	return fmt.Sprintf("(error) ERR Protocol error: %s", p.Message)
-}
-
-type ScannerError struct {
-	Message string
-}
-
-func (s ScannerError) Error() string {
-	return fmt.Sprintf("(error) ERR Input Scan error: %s", s.Message)
 }

--- a/errors/server/error.go
+++ b/errors/server/error.go
@@ -17,3 +17,12 @@ type ScannerError struct {
 func (s ScannerError) Error() string {
 	return fmt.Sprintf("-ERR Input Scan error: %s", s.Message)
 }
+
+type UnknownCommand struct {
+	Command string
+	Args    []string
+}
+
+func (u UnknownCommand) Error() string {
+	return fmt.Sprintf("(error) ERR unknown command '%v', with args beginning with: %v", u.Command, u.Args)
+}

--- a/server/exec.go
+++ b/server/exec.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	pkg "github.com/zenith"
+
+	errors "github.com/zenith/errors/server"
 	resp "github.com/zenith/redis-protocol"
 )
 
@@ -72,6 +74,6 @@ func (s *server) exec(input string) string {
 	case pkg.PingCMD:
 		return responder(s.db.Ping(), nil)
 	default:
-		return responder("", pkg.UnknownCommand{Command: cmd[0], Args: cmd[1:]})
+		return responder("", errors.UnknownCommand{Command: cmd[0], Args: cmd[1:]})
 	}
 }


### PR DESCRIPTION
since the errors were becoming spread and causing import cycle errors during import, I'm collating them in errors package into separate packages for client and server to be used